### PR TITLE
feat: force metallb subnet

### DIFF
--- a/p4p-server.yaml
+++ b/p4p-server.yaml
@@ -33,6 +33,7 @@ metadata:
   namespace: server-test
   annotations:
     metallb.universe.tf/allow-shared-ip: "mailbox-test-key"
+    metallb.universe.tf/address-pool: sdf-services
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.24.5.184
@@ -52,6 +53,7 @@ metadata:
   namespace: server-test
   annotations:
     metallb.universe.tf/allow-shared-ip: "mailbox-test-key"
+    metallb.universe.tf/address-pool: sdf-services
 spec:
   type: LoadBalancer
   loadBalancerIP: 172.24.5.184


### PR DESCRIPTION
due to our multi network setup with metallb, you will need to force the address-pool to use otherwise traffic could be blackholed.