### PR TITLE
feat: use a dedicated multus network interface for comms

### DIFF
--- a/p4p-server.yaml
+++ b/p4p-server.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app: mailbox-server
     app.kubernetes.io/name: mailbox-server
+  annotations:
+   k8s.v1.cni.cncf.io/networks: multus/sdf-ad-ingest
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This will attach a new IP interface into the Pod (like with a VM) so that communication in/out of that subnet will be direct to/from the client rather than going through the CNI machinations of kubernetes.